### PR TITLE
Refactor CLIRunner class to be static

### DIFF
--- a/src/Devantler.CLIRunner/CLIRunner.cs
+++ b/src/Devantler.CLIRunner/CLIRunner.cs
@@ -8,7 +8,7 @@ namespace Devantler.CLIRunner;
 /// <summary>
 /// A class to run CLI commands and capture their output.
 /// </summary>
-public class CLIRunner()
+public static class CLIRunner
 {
   /// <summary>
   /// Run a CLI command and capture its output.

--- a/src/Devantler.CLIRunner/Devantler.CLIRunner.csproj
+++ b/src/Devantler.CLIRunner/Devantler.CLIRunner.csproj
@@ -8,7 +8,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request updates the CLIRunner class to be static. This change allows for better performance and eliminates the need to create an instance of the class before using its methods. The CLIRunner class is responsible for running CLI commands and capturing their output. By making it static, it can now be accessed directly without the need for instantiation. This refactor improves code readability and simplifies the usage of the CLIRunner class.