### PR TITLE
Update .editorconfig and Treat Warnings as Errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -46,6 +46,9 @@ dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
 # Apply our rule to constants.
 dotnet_naming_style.constant_style.capitalization = pascal_case
 
+# Disable CA1014
+dotnet_diagnostic.CA1014.severity = none
+
 [*.{received,verified}.*]
 generated_code = true
 

--- a/Devantler.CLIRunner.Tests/Devantler.CLIRunner.Tests.csproj
+++ b/Devantler.CLIRunner.Tests/Devantler.CLIRunner.Tests.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>preview-all</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
 
@@ -27,5 +28,6 @@
   <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
+
 
 </Project>

--- a/Devantler.CLIRunner/Devantler.CLIRunner.csproj
+++ b/Devantler.CLIRunner/Devantler.CLIRunner.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>preview-all</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
This pull request includes updates to the .editorconfig file and the project file to treat warnings as errors. The .editorconfig file now disables the CA1014 diagnostic, and the project file sets the TreatWarningsAsErrors property to true. These changes ensure that warnings are treated as errors during the build process.