### PR TITLE
Replace Spectre.Console with Console for debug output in CLI

### DIFF
--- a/Devantler.CLIRunner/CLI.cs
+++ b/Devantler.CLIRunner/CLI.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using System.Text;
 using CliWrap;
 using CliWrap.EventStream;
-using Spectre.Console;
 
 namespace Devantler.CLIRunner;
 
@@ -38,7 +37,12 @@ public static class CLI
         {
           case StartedCommandEvent started:
             if (System.Diagnostics.Debugger.IsAttached || Environment.GetEnvironmentVariable("DEBUG") is not null)
-              AnsiConsole.MarkupLine($"[bold blue]DEBUG[/] Process started: {started.ProcessId}");
+            {
+              Console.ForegroundColor = ConsoleColor.Blue;
+              Console.Write("[DEBUG]");
+              Console.ResetColor();
+              Console.WriteLine($" Process started: {started.ProcessId}");
+            }
             break;
           case StandardOutputCommandEvent stdOut:
             if (!silent)
@@ -59,7 +63,12 @@ public static class CLI
             break;
           case ExitedCommandEvent exited:
             if (System.Diagnostics.Debugger.IsAttached || Environment.GetEnvironmentVariable("DEBUG") is not null)
-              AnsiConsole.MarkupLine($"[bold blue]DEBUG[/] Process exited with code {exited.ExitCode}");
+            {
+              Console.ForegroundColor = ConsoleColor.Blue;
+              Console.Write("[DEBUG]");
+              Console.ResetColor();
+              Console.WriteLine($" Process exited with {exited.ExitCode}");
+            }
             break;
           default:
             throw new CLIException($"Unsupported event type {cmdEvent.GetType()}"); // This should never happen

--- a/Devantler.CLIRunner/Devantler.CLIRunner.csproj
+++ b/Devantler.CLIRunner/Devantler.CLIRunner.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="CLIWrap" Version="3.6.7" />
-    <PackageReference Include="Spectre.Console" Version="0.49.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Remove the Spectre.Console dependency and replace its usage with Console for debug output in the CLI. This simplifies the code and reduces external dependencies.